### PR TITLE
Added some Documentation and renamed MONGOHQ_URL to MONGO_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,48 @@
-dokku-mongodb-plugin
-====================
-
+MongoDB plugin for Dokku
+---------------------------
 Plugin to setup Mongodb accounts for containers deployed to Dokku
+
+
+Installation
+------------
+```
+git clone https://github.com/jeffutter/dokku-mongodb-plugin.git /var/lib/dokku/plugins/mongodb
+dokku plugins-install
+```
+
+
+Commands
+--------
+```
+$ dokku help
+     mongodb:create <app>   Create a Mongo database
+     mongodb:delete <app>   Delete specified Mongo database
+     mongodb:list           List all databases
+```
+
+Simple usage
+------------
+Your need to have app running with the same name!
+
+Create a new DB:
+```
+$ dokku mongodb:create foo            # Server side
+$ ssh dokku@server mongodb:create foo # Client side
+
+    {
+        "_id" : ObjectId("524c90dc45addf0edad783a2"),
+        "user" : "foo",
+        "readOnly" : false,
+        "pwd" : "825ec0deacccb3c6bb621d84153e5877"
+    }
+
+```
+
+Now if you push your app again, you will have the following ENV variables
+```
+MONGODB_DATABASE
+MONGODB_PORT
+MONGODB_USERNAME
+MONGODB_PASSWORD
+MONGO_URL
+```

--- a/commands
+++ b/commands
@@ -69,7 +69,7 @@ case "$1" in
     set_dokku_env $app_path/ENV MONGODB_PORT $mongodb_port
     set_dokku_env $app_path/ENV MONGODB_USERNAME $mongodb_username
     set_dokku_env $app_path/ENV MONGODB_PASSWORD $mongodb_password
-    set_dokku_env $app_path/ENV MONGOHQ_URL "mongodb://${mongodb_username}:${mongodb_password}@${mongodb_ip}:${mongodb_port}/${mongodb_database}"
+    set_dokku_env $app_path/ENV MONGO_URL "mongodb://${mongodb_username}:${mongodb_password}@${mongodb_ip}:${mongodb_port}/${mongodb_database}"
     chown git: $app_path/ENV
     ;;
   mongodb:delete)
@@ -81,8 +81,8 @@ case "$1" in
       touch $app_path/ENV
     fi
 
-    VARS=( "MONGODB_DATABASE" "MONGODB_USERNAME" "MONGODB_PASSWORD" "MONGODB_PORT"  "MONGOHQ_URL")
-    clear_dokku_env VARS 
+    VARS=( "MONGODB_DATABASE" "MONGODB_USERNAME" "MONGODB_PASSWORD" "MONGODB_PORT"  "MONGO_URL")
+    clear_dokku_env VARS
 
     chown git: $app_path/ENV
     ;;


### PR DESCRIPTION
Thanks for the great plugin. I've added some documentation and renamed the MONGOHQ_URL variable to MONGO_URL. Otherwise people think this is connected to https://mongohq.com/

What was your motivation to not allow the creation of a instance without an app? Maybe people want to share a mongodb with two apps. What do you think about using a pre-release hook to link the app to the db?
