### PR TITLE
Fixed commands for dokku latest version

### DIFF
--- a/commands
+++ b/commands
@@ -111,5 +111,3 @@ EOF
 esac
 
 HOME=$OLDHOME
-
-cat


### PR DESCRIPTION
Since commit 455be29249664101262a788a8c8a945d65c7339a, the `cat` is no longer needed, and forces to type `Ctrl-D` to terminates the commands.
