### PR TITLE
Give some time to mongodb before trying to connect

### DIFF
--- a/install
+++ b/install
@@ -26,6 +26,7 @@ if [[ ! -d "$DOKKU_ROOT/.mongodb" ]]; then
     mongodb_ip=localhost
   fi
 
+  sleep 2 # give mongodb some time to start
   mongo $mongodb_ip:$mongodb_port/admin --eval "db.addUser(\"admin\", \"${admin_pass}\")"
   docker stop "$id"
 fi


### PR DESCRIPTION
If docker and mongodb do not start fast enough, creating the admin fails. I added a sleep of 2 seconds to workaround this, there's probably a cleaner way to do this, but I don't know how.
