### PR TITLE
Added looping on install, giving mongod time to start.

### DIFF
--- a/install
+++ b/install
@@ -37,8 +37,19 @@ if [[ ! -d "$DOKKU_ROOT/.mongodb" ]]; then
     mongodb_ip=localhost
   fi
 
-  sleep 2 # give mongodb some time to start
-  mongo $mongodb_ip:$mongodb_port/admin --eval "db.addUser(\"admin\", \"${admin_pass}\")"
+  admin_id=""
+  loop_count=0
+  while [ -z "$admin_id" -a $loop_count -lt 100 ];
+  do
+    echo "Connecting to server and creating admin user"
+    sleep 2 # give mongodb some time to start
+    admin_id=$(mongo $mongodb_ip:$mongodb_port/admin --eval "db.addUser(\"admin\", \"${admin_pass}\")" | grep "_id" | awk '{split($0,a,":");split(a[2],b,"\""); print b[2]}')
+    loop_count=$((loop_count + 1))
+  done
   docker stop "$id"
+
+  if [ -z $admin_id ]; then
+    echo "Unable to create the admin user!" 
+  fi
 fi
 


### PR DESCRIPTION
During the install phase, if mongod hadn't completed startup, the call to add the admin user would fail and prevent the user from executing commands.  This fix will loop for a maximum of 200 seconds trying to connect and create the admin user.  Fixes #18.
