### PR TITLE
Fixed errors/warnings related with "mongodb:start" command

### DIFF
--- a/commands
+++ b/commands
@@ -110,7 +110,12 @@ case "$1" in
     if [[ "$id" != "" ]]; then
       echo "MongoDB container already running with ID: ${id}"
     else
-      docker run -p 27017 -v "$DOKKU_ROOT/.mongodb/data":/tmp/mongo --name="dokku-mongodb" -d "$IMAGE" /usr/bin/mongod --dbpath=/tmp/mongo --auth
+      id=$(docker ps -a | grep "$db_image:latest[[:space:]].\+[[:space:]]dokku-mongodb[[:space:]]*$" |  awk '{print $1}')
+      if [[ "$id" != "" ]]; then
+        docker start $id
+      else
+        docker run -p 27017 -v "$DOKKU_ROOT/.mongodb/data":/tmp/mongo --name="dokku-mongodb" -d "$IMAGE" /usr/bin/mongod --dbpath=/tmp/mongo --auth
+      fi
     fi
     ;;
   mongodb:stop)


### PR DESCRIPTION
1. I'm getting the following warning after upgrading to Docker 0.9.0:
   "Warning: '-name' is deprecated, it will be removed soon. See usage."
   I've updated the "run" command option to fix this warning.
2. Running "mongodb:start" after "mongodb:stop" gives the following error:
   "Error: Conflict, The name dokku-mongodb is already assigned to CONTAINERID. You have to delete (or rename) that container to be able to assign dokku-mongodb to a container again."
   I've changed code to create new MongoDB container (using "run") only if it does not exist.
