### PR TITLE
Replace all .'s in app name with _ for database name

### DIFF
--- a/commands
+++ b/commands
@@ -36,7 +36,7 @@ set_dokku_env() {
 }
 
 admin_pass=$(cat "$DOKKU_ROOT/.mongodb/admin_pw")
-mongodb_database="${APP/./_}-production"
+mongodb_database="${APP//./_}-production"
 
 db_image="jeffutter/mongodb"
 id=$(docker ps | grep "$db_image":latest |  awk '{print $1}')


### PR DESCRIPTION
Currently only the first `.` in app name is replaced with an `_` for the database name, which results in a mongo error along the lines of `Error: [staging_exampleapp.com-production] is not a valid database name at src/mongo/shell/mongo.js:40
exception: connect failed`

Updated the mongodb_database regex to replace all .'s, so `APP=staging.exampleapp.com` becomes `staging_exampleapp_com-production`
