### PR TITLE
Rollback password file on createUser fail. Updated createUser schema.

### DIFF
--- a/commands
+++ b/commands
@@ -125,7 +125,7 @@ case "$1" in
     if [[ $? == 1 ]]; then
       echo "Creating user ${mongodb_username}"
       ### New 2.6 schema (version 3)
-      mongo $mongodb_public_ip:$mongodb_port/$mongodb_database --quiet -u admin -p"$admin_pass" --authenticationDatabase="admin" --eval "db.createUser({user: \"${mongodb_username}\", pwd: \"${mongodb_password}\", roles : [{ role : \"dbOwner\", db: \"$mongodb_database\"}] })"
+      mongo $mongodb_public_ip:$mongodb_port/$mongodb_database --quiet -u admin -p"$admin_pass" --authenticationDatabase="admin" --eval "db.createUser({user: \"${mongodb_username}\", pwd: \"${mongodb_password}\", roles : [{ role : \"dbOwner\", db: \"${mongodb_database}\"}] })"
 
       ### Old schema
       # mongo $mongodb_public_ip:$mongodb_port/$mongodb_database --quiet -u admin -p"$admin_pass" --authenticationDatabase="admin" --eval "db.createUser({user: \"${mongodb_username}\", pwd: \"${mongodb_password}\", roles: [\"dbOwner\"]})"


### PR DESCRIPTION
Rollback password file change when createUser fails (ie. user already on the db).

Updated createUser schema to MongoDB >= 2.6, schema version: 3. http://docs.mongodb.org/manual/release-notes/2.6-upgrade/#authentication
http://docs.mongodb.org/manual/release-notes/2.6-upgrade-authorization/#upgrade-authorization-model

Fixes issue #39 after MongoDB 2.6.x update and upgrade.
