### PR TITLE
added userDrop to get rid of newly made $APP mongodb username

### DIFF
--- a/commands
+++ b/commands
@@ -137,6 +137,8 @@ case "$1" in
     check_app
 
     mongo $mongodb_public_ip:$mongodb_port/$mongodb_database --quiet -u admin -p"$admin_pass" --authenticationDatabase="admin" --eval "printjson(db.dropDatabase())"
+   
+    mongo $mongodb_public_ip:$mongodb_port/$mongodb_database --quiet -u admin -p"$admin_pass" --authenticationDatabase="admin" --eval "db.dropUser(\"${APP}\")"
 
     dokku config:unset "$APP" MONGODB_DATABASE \
       MONGODB_HOST \


### PR DESCRIPTION
Added:

mongo $mongodb_public_ip:$mongodb_port/$mongodb_database --quiet -u admin -p"$admin_pass" --authenticationDatabase="admin" --eval "db.dropUser(\"${APP}\")"

to counter the:

mongo $mongodb_public_ip:$mongodb_port/$mongodb_database --quiet -u admin -p"$admin_pass" --authenticationDatabase="admin" --eval "db.createUser({user: \"${mongodb_username}\", pwd: \"${mongodb_password}\", roles : [{ role : \"dbOwner\", db: \"${mongodb_database}\"}] })"
