### PR TITLE
Fix install with correct mongo client

### DIFF
--- a/commands
+++ b/commands
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -e;
+[[ $DOKKU_TRACE ]] && set -x
 
 if [[ -z "$3"  ]]; then
   APP=$2

--- a/install
+++ b/install
@@ -57,7 +57,7 @@ fi
 apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
 echo deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen > /etc/apt/sources.list.d/10gen.list
 apt-get update
-apt-get -y install mongodb-clients
+apt-get -y install mongodb-org-shell
 
 if [ $previous_mongo_install = false ]; then
   echo 'ENABLE_MONGODB="no"' > /etc/default/mongodb

--- a/install
+++ b/install
@@ -57,7 +57,7 @@ fi
 apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
 echo deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen > /etc/apt/sources.list.d/10gen.list
 apt-get update
-apt-get -y install mongodb-org-shell
+apt-get -y install mongodb-org-shell mongodb-org-tools
 
 if [ $previous_mongo_install = false ]; then
   echo 'ENABLE_MONGODB="no"' > /etc/default/mongodb

--- a/install
+++ b/install
@@ -1,4 +1,5 @@
 #!/bin/bash
+[[ $DOKKU_TRACE ]] && set -x
 
 vercomp () {
   if [[ $1 == $2 ]]

--- a/pre-release
+++ b/pre-release
@@ -1,4 +1,5 @@
 #!/bin/bash
+[[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
 


### PR DESCRIPTION
The error that I am receiving when running `dokku plugins-install` with `set -x` is:

```
+ echo MongoDB shell version: 2.4.9 connecting to: 127.0.0.1:49159/admin Thu Mar 19 11:25:34.904 TypeError: Property ''\''createUser'\''' of object admin is not a function
```

The install script was installing the wrong client (2.4.9):

```
$ apt-cache policy mongodb-clients
mongodb-clients:
  Installed: 1:2.4.9-1ubuntu2
  Candidate: 1:2.4.9-1ubuntu2
  Version table:
 *** 1:2.4.9-1ubuntu2 0
        500 http://mirrors.digitalocean.com/ubuntu/ trusty/universe amd64 Packages
        100 /var/lib/dpkg/status
```

The correct way is to use `10gen` package `mongodb-org-shell`:

```
$ apt-get install mongodb-org-shell
The following packages will be REMOVED:
  mongodb-clients
The following NEW packages will be installed:
  mongodb-org-shell
```

This fixes #47.