### PR TITLE
Use dokku config:set-norestart command instead of writing configs directly to the ENV files 

### DIFF
--- a/commands
+++ b/commands
@@ -196,7 +196,7 @@ Please check whether you have sufficient write privileges in $PWD"
 
       mongodb_username=$APP
 
-      # Have to set ENV vars this way. Using dokku config:set causes a loop where it tries to redeploy itself and calls this again
+      # We can use dokku config:set-norestart to avoid redeploy itself
 
       dokku config:set-norestart "$APP" MONGODB_DATABASE="$mongodb_database"
       dokku config:set-norestart "$APP" MONGODB_HOST="$mongodb_private_ip"

--- a/commands
+++ b/commands
@@ -196,7 +196,7 @@ Please check whether you have sufficient write privileges in $PWD"
 
       mongodb_username=$APP
 
-      dokku config:set-norestart "$APP" MONGODB_DATABASE="$mongodb_database" [MONGODB_HOST="$mongodb_private_ip" MONGODB_PORT="$mongodb_internal_port" MONGODB_USERNAME="$mongodb_username" MONGODB_PASSWORD="$mongodb_password" MONGO_URL="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}" MONGO_URI="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"]
+      dokku config:set-norestart "$APP" MONGODB_DATABASE="$mongodb_database" MONGODB_HOST="$mongodb_private_ip" MONGODB_PORT="$mongodb_internal_port" MONGODB_USERNAME="$mongodb_username" MONGODB_PASSWORD="$mongodb_password" MONGO_URL="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}" MONGO_URI="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"
 
       echo
       echo "-----> $APP linked to $db_image container"

--- a/commands
+++ b/commands
@@ -196,16 +196,7 @@ Please check whether you have sufficient write privileges in $PWD"
 
       mongodb_username=$APP
 
-      # We can use dokku config:set-norestart to avoid redeploy itself
-
-      dokku config:set-norestart "$APP" MONGODB_DATABASE="$mongodb_database"
-      dokku config:set-norestart "$APP" MONGODB_HOST="$mongodb_private_ip"
-      dokku config:set-norestart "$APP" MONGODB_PORT="$mongodb_internal_port"
-      dokku config:set-norestart "$APP" MONGODB_USERNAME="$mongodb_username"
-      dokku config:set-norestart "$APP" MONGODB_PASSWORD="$mongodb_password"
-      dokku config:set-norestart "$APP" MONGO_URL="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"
-      dokku config:set-norestart "$APP" MONGO_URI="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"
-
+      dokku config:set-norestart "$APP" MONGODB_DATABASE="$mongodb_database" [MONGODB_HOST="$mongodb_private_ip" MONGODB_PORT="$mongodb_internal_port" MONGODB_USERNAME="$mongodb_username" MONGODB_PASSWORD="$mongodb_password" MONGO_URL="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}" MONGO_URI="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"]
 
       echo
       echo "-----> $APP linked to $db_image container"

--- a/commands
+++ b/commands
@@ -198,13 +198,13 @@ Please check whether you have sufficient write privileges in $PWD"
 
       # Have to set ENV vars this way. Using dokku config:set causes a loop where it tries to redeploy itself and calls this again
 
-      set_dokku_env MONGODB_DATABASE "$mongodb_database"
-      set_dokku_env MONGODB_HOST "$mongodb_private_ip"
-      set_dokku_env MONGODB_PORT "$mongodb_internal_port"
-      set_dokku_env MONGODB_USERNAME "$mongodb_username"
-      set_dokku_env MONGODB_PASSWORD "$mongodb_password"
-      set_dokku_env MONGO_URL "mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"
-      set_dokku_env MONGO_URI "mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"
+      dokku config:set-norestart "$APP" MONGODB_DATABASE="$mongodb_database"
+      dokku config:set-norestart "$APP" MONGODB_HOST="$mongodb_private_ip"
+      dokku config:set-norestart "$APP" MONGODB_PORT="$mongodb_internal_port"
+      dokku config:set-norestart "$APP" MONGODB_USERNAME="$mongodb_username"
+      dokku config:set-norestart "$APP" MONGODB_PASSWORD="$mongodb_password"
+      dokku config:set-norestart "$APP" MONGO_URL="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"
+      dokku config:set-norestart "$APP" MONGO_URI="mongodb://${mongodb_username}:${mongodb_password}@${mongodb_private_ip}:${mongodb_internal_port}/${mongodb_database}"
 
 
       echo


### PR DESCRIPTION
With that change, dokku mongodb:link app db works for me and I can see a newly created database with dokku mongodb:list