### PR TITLE
Mongo Private IP is getting null at the end.

### DIFF
--- a/commands
+++ b/commands
@@ -113,7 +113,7 @@ mongodb_database="${DATABASE//./_}-production"
 id=$(docker ps | grep "$db_image" |  awk '{print $1}')
 if [[ -n "$id" ]]; then
   mongodb_public_ip=$(docker port ${id} 27017 | awk '{split($0,a,":"); print a[1]}')
-  mongodb_private_ip=$(docker inspect ${id} | grep IPAddress | awk '{ print $2 }' | tr -d ',"')
+  mongodb_private_ip=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${id})
   mongodb_port=$(docker port ${id} 27017 | awk '{split($0,a,":"); print a[2]}')
   if [[ $mongodb_public_ip = "0.0.0.0" ]]; then
     mongodb_public_ip=localhost


### PR DESCRIPTION
On Docker version 1.7.0, build 0baf609 I'm getting a null after the IP Address that's messing the build_env stage on dokku 0.3.18.
I modify this line to get in other way the docker private ip from containers, it is getting correctly the IP.